### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Convert Kivy app to APK'
 inputs:
   python-version:
     description: 'Python version to use'
-    default: '3.12'
+    default: '3.8'
   workdir:
     default: '.'
     description: 'Working directory'


### PR DESCRIPTION
Buildozer require distutils module and in Python 12 the distutils module is deprecated so that's why we can't use Python 12 that's why I again change it to the Python 8