### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,6 @@ runs:
           zlib1g-dev \
           libncurses5-dev \
           libncursesw5-dev \
-          libtinfo5 \
           cmake \
           libffi-dev \
           libssl-dev

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,12 @@ runs:
           libncursesw5-dev \
           cmake \
           libffi-dev \
+          build-essential \
+          libstdc++6 \
+          aidl \
           libssl-dev
+        wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+        sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
         export PATH=$PATH:~/.local/bin/
         python3 -m pip install --upgrade \
           Cython==0.29.33 \

--- a/action.yml
+++ b/action.yml
@@ -61,10 +61,12 @@ runs:
           libffi-dev \
           build-essential \
           libstdc++6 \
+          automake \
           aidl \
           libssl-dev
         wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
         sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+        python3 -m pip install libtool
         export PATH=$PATH:~/.local/bin/
         python3 -m pip install --upgrade \
           Cython==0.29.33 \

--- a/action.yml
+++ b/action.yml
@@ -63,10 +63,12 @@ runs:
           libstdc++6 \
           automake \
           aidl \
+          libltdl-dev \
           libssl-dev
         wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
         sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
         python3 -m pip install libtool
+        python3 -m pip install docwriter
         export PATH=$PATH:~/.local/bin/
         python3 -m pip install --upgrade \
           Cython==0.29.33 \


### PR DESCRIPTION
The dependency libinfo 5 is currently uninstallable on most debian based systems via apt, so i fetched it manually with wget and install it to avoid any errors.